### PR TITLE
Fix console folder autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "autoload": {
         "psr-4": {
             "Yarob\\LaravelServiceGenerator\\": "src/",
-            "Yarob\\LaravelServiceGenerator\\Tests\\": "tests"
+            "Yarob\\LaravelServiceGenerator\\Tests\\": "tests",
+            "Yarob\\LaravelServiceGenerator\\Console\\": "src/console"
         }
     },
 


### PR DESCRIPTION
During "composer require yarooob/laravel-service-generator" this error is causing:
```php
Class Yarob\LaravelServiceGenerator\Console\ServiceMakeCommand located in ./vendor/yarooob/laravel-service-generator/src/console/ServiceMakeCommand.php does not comply with psr-4 autoloading standard. Skipping.
Class Yarob\LaravelServiceGenerator\Console\ServiceInterfaceMakeCommand located in ./vendor/yarooob/laravel-service-generator/src/console/ServiceInterfaceMakeCommand.php does not comply with psr-4 autoloading standard. Skipping.
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

   Illuminate\Contracts\Container\BindingResolutionException 

  Target class [Yarob\LaravelServiceGenerator\Console\ServiceMakeCommand] does not exist.

  at vendor/laravel/framework/src/Illuminate/Container/Container.php:811
    807▕ 
    808▕         try {
    809▕             $reflector = new ReflectionClass($concrete);
    810▕         } catch (ReflectionException $e) {
  ➜ 811▕             throw new BindingResolutionException("Target class [$concrete] does not exist.", 0, $e);
    812▕         }
    813▕ 
    814▕         // If the type is not instantiable, the developer is attempting to resolve
    815▕         // an abstract type such as an Interface or Abstract Class and there is

      +13 vendor frames 
  14  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```